### PR TITLE
add organisation partition option

### DIFF
--- a/tap_apple_search_ads/tap.py
+++ b/tap_apple_search_ads/tap.py
@@ -10,6 +10,7 @@ from singer_sdk.typing import (
     PropertiesList,
     Property,
     StringType,
+    ArrayType,
 )  # JSON schema typing helpers
 
 from tap_apple_search_ads import streams
@@ -24,22 +25,27 @@ class TapAppleSearchAds(Tap):
         Property(
             "client_id",
             StringType,
-            required=True,
             secret=True,  # Flag config as protected.
             description="The client id to authenticate against the API service",
         ),
         Property(
             "client_secret",
             StringType,
-            required=True,
             secret=True,  # Flag config as protected.
             description="The client secret to authenticate against the API service",
         ),
         Property(
             "org_id",
             StringType,
-            required=True,
-            description="The organisation id in your apple search ads.",
+            description="The organisation that you want to sync. Superseded by `org_ids` if that is set.",
+        ),
+        Property(
+            "org_ids",
+            ArrayType(StringType),
+            description="The organisations that you want to sync. The client_ids and client_secrets must be mapped to "
+            "`TAP_APPLE_SEARCH_ADS_CLIENT_ID__<org_id>` and `TAP_APPLE_SEARCH_ADS_CLIENT_SECRET__<org_id>` "
+            "environment variables respectively. If you are just syncing one organisation, you can use the standard "
+            "env variables or the config values.",
         ),
         Property(
             "start_date",
@@ -55,13 +61,20 @@ class TapAppleSearchAds(Tap):
         Property(
             "report_granularity",
             StringType,
-            description=(
-                "The granularity of reporting streams. "
-                "One of HOURLY, DAILY, WEEKLY, MONTHLY."
-            ),
+            description=("The granularity of reporting streams. " "One of HOURLY, DAILY, WEEKLY, MONTHLY."),
             allowed_values=["HOURLY", "DAILY", "WEEKLY", "MONTHLY"],
         ),
     ).to_dict()
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the tap."""
+        super().__init__(*args, **kwargs)
+        if not (
+            (self.config.get("org_id") and self.config.get("client_id") and self.config.get("client_secret"))
+            or self.config.get("org_ids")
+        ):
+            msg = "You must provide either `org_id` or `org_ids` in the config."
+            raise ValueError(msg)
 
     def discover_streams(self) -> list[streams.AppleSearchAdsStream]:
         """Return a list of discovered streams.


### PR DESCRIPTION
required a bit of hacking but you can now partition this tap based on multiple organisation ids. you just need to replace `client_id`, `client_secret` and `org_id` with `org_ids`, and map the client_ids and client secrets accordingly (check the docs). this is backwards compatible